### PR TITLE
FCM トークンの送信処理をKarte SDK v1.5.3対応する

### DIFF
--- a/app/src/main/java/io/karte/tracker_sample/MyKarteFirebaseInstanceIdService.java
+++ b/app/src/main/java/io/karte/tracker_sample/MyKarteFirebaseInstanceIdService.java
@@ -1,11 +1,17 @@
 package io.karte.tracker_sample;
 
+import com.google.firebase.iid.FirebaseInstanceId;
+import com.google.firebase.iid.FirebaseInstanceIdService;
+
 import io.karte.android.tracker.Tracker;
-import io.karte.android.tracker.firebase.KarteFirebaseInstanceIdService;
 
-public class MyKarteFirebaseInstanceIdService extends KarteFirebaseInstanceIdService {
+public class MyKarteFirebaseInstanceIdService extends FirebaseInstanceIdService {
 
-  protected Tracker getTracker() {
-    return Tracker.getInstance(this, SampleApp.APP_KEY);
+  @Override
+  public void onTokenRefresh() {
+    super.onTokenRefresh();
+    final String token = FirebaseInstanceId.getInstance().getToken();
+    Tracker.getInstance(this, SampleApp.APP_KEY).trackFcmToken(token);
   }
+
 }


### PR DESCRIPTION
対応内容はISSUEに記載しています。
#5 