### PR TITLE
AndroidManifest.xmlに削除したMyKarteFirebaseInstanceIdServiceの定義が残っている

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,11 +18,6 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <service android:name=".MyKarteFirebaseInstanceIdService">
-            <intent-filter>
-                <action android:name="com.google.firebase.INSTANCE_ID_EVENT"/>
-            </intent-filter>
-        </service>
         <service android:name=".MyFirebaseMessagingService">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />


### PR DESCRIPTION
AndroidManifest.xmlに削除したMyKarteFirebaseInstanceIdServiceの定義が残っているので削除いたしました。

closes #7 